### PR TITLE
Make `Portal._get_ext_addr()` return a unique set

### DIFF
--- a/python/quic_portal/__init__.py
+++ b/python/quic_portal/__init__.py
@@ -2,8 +2,9 @@
 QUIC Portal - High-performance QUIC communication with NAT traversal
 """
 
+from .constants import VERSION
 from .portal import Portal, QuicTransportOptions
 from .exceptions import PortalError, ConnectionError
 
 __all__ = ["Portal", "QuicTransportOptions", "PortalError", "ConnectionError"]
-__version__ = "0.1.13"
+__version__ = VERSION

--- a/python/quic_portal/constants.py
+++ b/python/quic_portal/constants.py
@@ -1,0 +1,4 @@
+from typing import Final
+
+
+VERSION: Final[str] = "0.1.13"


### PR DESCRIPTION
instead of list of external IP and ports so caller doesn't have to de-dupe later.

Also simplify some other code in `Portal` and log the quic_portal version at the beginning of both `Portal.create_server()` and `Portal.create_client()`.